### PR TITLE
Fix compile.h header

### DIFF
--- a/mruby/files/KOSMakefile.mk
+++ b/mruby/files/KOSMakefile.mk
@@ -68,3 +68,6 @@ fixincludes:
 	@for _file in $(MRUBY_INCLUDE_DIR)/*.h; do \
 		sed -i -e 's/#include <mruby\/mruby\/mrbconf.h>/#include <mruby\/mrbconf.h>/g' $$_file $(SED_FLAGS); \
 	done
+	@for _file in $(MRUBY_INCLUDE_MRUBY_DIR)/*.h; do \
+		sed -i -e 's/#include <mruby\/mruby\/mruby\/mempool.h>/#include <mruby\/mruby\/mempool.h>/g' $$_file $(SED_FLAGS); \
+	done


### PR DESCRIPTION
Fixed header by making sure mempool.h headers location is correctly set.